### PR TITLE
Add support for configurable audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ from fastapi_oidc import get_auth
 
 OIDC_config = {
     "client_id": "0oa1e3pv9opbyq2Gm4x7",
+    "audience": "https://yourapi.url.com/api",
     "base_authorization_server_uri": "https://dev-126594.okta.com",
     "issuer": "dev-126594.okta.com",
     "signature_cache_ttl": 3600,

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ from fastapi_oidc import get_auth
 
 OIDC_config = {
     "client_id": "0oa1e3pv9opbyq2Gm4x7",
+    # Audience can be omitted in which case the aud value defaults to client_id
     "audience": "https://yourapi.url.com/api",
     "base_authorization_server_uri": "https://dev-126594.okta.com",
     "issuer": "dev-126594.okta.com",

--- a/fastapi_oidc/auth.py
+++ b/fastapi_oidc/auth.py
@@ -33,7 +33,7 @@ from fastapi_oidc.types import IDToken
 def get_auth(
     *_,
     client_id: str,
-    audience: str,
+    audience: str = None,
     base_authorization_server_uri: str,
     issuer: str,
     signature_cache_ttl: int,
@@ -45,7 +45,8 @@ def get_auth(
 
     Args:
         client_id (str): This string is provided when you register with your resource server.
-        audience (str): The audience string configured by your auth server.
+        audience (str): (Optional) The audience string configured by your auth server.
+            If not set defaults to client_id
         base_authorization_server_uri(URL): Everything before /.wellknow in your auth server URL.
             I.E. https://dev-123456.okta.com
         issuer (URL): Same as base_authorization. This is used to generating OpenAPI3.0 docs which
@@ -96,7 +97,7 @@ def get_auth(
                 id_token,
                 key,
                 algorithms,
-                audience=audience,
+                audience=audience if audience else client_id,
                 issuer=issuer,
                 # Disabled at_hash check since we aren't using the access token
                 options={"verify_at_hash": False},

--- a/fastapi_oidc/auth.py
+++ b/fastapi_oidc/auth.py
@@ -16,7 +16,8 @@ Usage
         return f"Hello {name}"
 """
 
-from typing import Callable, Optional
+from typing import Callable
+from typing import Optional
 
 from fastapi import Depends
 from fastapi import HTTPException

--- a/fastapi_oidc/auth.py
+++ b/fastapi_oidc/auth.py
@@ -33,6 +33,7 @@ from fastapi_oidc.types import IDToken
 def get_auth(
     *_,
     client_id: str,
+    audience: str,
     base_authorization_server_uri: str,
     issuer: str,
     signature_cache_ttl: int,
@@ -44,6 +45,7 @@ def get_auth(
 
     Args:
         client_id (str): This string is provided when you register with your resource server.
+        audience (str): The audience string configured by your auth server.
         base_authorization_server_uri(URL): Everything before /.wellknow in your auth server URL.
             I.E. https://dev-123456.okta.com
         issuer (URL): Same as base_authorization. This is used to generating OpenAPI3.0 docs which
@@ -94,8 +96,7 @@ def get_auth(
                 id_token,
                 key,
                 algorithms,
-                # TODO Check that client ID will always equal audience
-                audience=client_id,
+                audience=audience,
                 issuer=issuer,
                 # Disabled at_hash check since we aren't using the access token
                 options={"verify_at_hash": False},

--- a/fastapi_oidc/auth.py
+++ b/fastapi_oidc/auth.py
@@ -33,7 +33,7 @@ from fastapi_oidc.types import IDToken
 def get_auth(
     *_,
     client_id: str,
-    audience: str = None,
+    audience: Optional[str] = None,
     base_authorization_server_uri: str,
     issuer: str,
     signature_cache_ttl: int,

--- a/fastapi_oidc/auth.py
+++ b/fastapi_oidc/auth.py
@@ -16,7 +16,7 @@ Usage
         return f"Hello {name}"
 """
 
-from typing import Callable
+from typing import Callable, Optional
 
 from fastapi import Depends
 from fastapi import HTTPException

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -36,6 +36,7 @@ class Fixtures:
 
 TEST_CONFIG = {
     "client_id": "CongenitalOptimist",
+    "audience": "NeverAgain",
     "base_authorization_server_uri": "WhatAreTheCivilianApplications?",
     "issuer": "PokeItWithAStick",
     "signature_cache_ttl": 6e3,
@@ -46,12 +47,13 @@ def _make_token(
     email: str,
     private_key: str = Fixtures.TESTING_PRIVATE_KEY,
     client_id: str = str(TEST_CONFIG["client_id"]),
+    audience: str = str(TEST_CONFIG["audience"]),
     issuer: str = str(TEST_CONFIG["issuer"]),
 ) -> str:
     now = int(time.time())
     return jwt.encode(
         {
-            "aud": client_id,
+            "aud": audience,
             "iss": issuer,
             "email": email,
             "name": "SweetAndFullOfGrace",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -50,6 +50,7 @@ TEST_CONFIG_NO_AUD = {
     "signature_cache_ttl": 6e3,
 }
 
+
 def _make_token(
     email: str,
     private_key: str = Fixtures.TESTING_PRIVATE_KEY,
@@ -79,6 +80,7 @@ def _make_token(
         private_key,
         algorithm="RS256",
     ).decode("UTF-8")
+
 
 # Make a token where audience is client_id
 def _make_token_no_aud(
@@ -110,6 +112,7 @@ def _make_token_no_aud(
         algorithm="RS256",
     ).decode("UTF-8")
 
+
 def test__authenticate_user(monkeypatch):
     def mock_discovery(*args, **kwargs):
         class functions:
@@ -125,6 +128,7 @@ def test__authenticate_user(monkeypatch):
     authenticate_user = auth.get_auth(**TEST_CONFIG)
     IDToken = authenticate_user(auth_header=f"Bearer {token}")
     assert IDToken.email == email  # nosec
+
 
 # Ensure that when no audience is supplied, that the audience defaults to client ID
 def test__authenticate_user_no_aud(monkeypatch):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -78,7 +78,7 @@ def _make_token(
         },
         private_key,
         algorithm="RS256",
-    )
+    ).decode("UTF-8")
 
 # Make a token where audience is client_id
 def _make_token_no_aud(
@@ -108,7 +108,7 @@ def _make_token_no_aud(
         },
         private_key,
         algorithm="RS256",
-    )
+    ).decode("UTF-8")
 
 def test__authenticate_user(monkeypatch):
     def mock_discovery(*args, **kwargs):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -42,6 +42,13 @@ TEST_CONFIG = {
     "signature_cache_ttl": 6e3,
 }
 
+# Test configuration without audience
+TEST_CONFIG_NO_AUD = {
+    "client_id": "CongenitalOptimist",
+    "base_authorization_server_uri": "WhatAreTheCivilianApplications?",
+    "issuer": "PokeItWithAStick",
+    "signature_cache_ttl": 6e3,
+}
 
 def _make_token(
     email: str,
@@ -71,8 +78,37 @@ def _make_token(
         },
         private_key,
         algorithm="RS256",
-    ).decode("UTF-8")
+    )
 
+# Make a token where audience is client_id
+def _make_token_no_aud(
+    email: str,
+    private_key: str = Fixtures.TESTING_PRIVATE_KEY,
+    client_id: str = str(TEST_CONFIG_NO_AUD["client_id"]),
+    issuer: str = str(TEST_CONFIG_NO_AUD["issuer"]),
+) -> str:
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "aud": client_id,
+            "iss": issuer,
+            "email": email,
+            "name": "SweetAndFullOfGrace",
+            "preferred_username": "Sweet",
+            "exp": now + 30,
+            "auth_time": now,
+            "sub": "foo",
+            "ver": "1",
+            "iat": now,
+            "jti": str(uuid.uuid4()),
+            "amr": [],
+            "idp": "",
+            "nonce": "",
+            "at_hash": "",
+        },
+        private_key,
+        algorithm="RS256",
+    )
 
 def test__authenticate_user(monkeypatch):
     def mock_discovery(*args, **kwargs):
@@ -89,3 +125,21 @@ def test__authenticate_user(monkeypatch):
     authenticate_user = auth.get_auth(**TEST_CONFIG)
     IDToken = authenticate_user(auth_header=f"Bearer {token}")
     assert IDToken.email == email  # nosec
+
+# Ensure that when no audience is supplied, that the audience defaults to client ID
+def test__authenticate_user_no_aud(monkeypatch):
+    def mock_discovery(*args, **kwargs):
+        class functions:
+            auth_server = lambda **_: Fixtures.OIDC_DISCOVERY_RESPONSE
+            public_keys = lambda _: Fixtures.TESTING_PUBLIC_KEY
+            signing_algos = lambda x: x["id_token_signing_alg_values_supported"]
+
+        return functions
+
+    monkeypatch.setattr(auth.discovery, "configure", mock_discovery)
+    email = "AnticipationOfANewLoversArrivalThe@VeryLittleGravitasIndeed"
+    token = _make_token_no_aud(email=email)
+    authenticate_user = auth.get_auth(**TEST_CONFIG_NO_AUD)
+    IDToken = authenticate_user(auth_header=f"Bearer {token}")
+    assert IDToken.email == email  # nosec
+    assert IDToken.aud == TEST_CONFIG_NO_AUD["client_id"]


### PR DESCRIPTION
Hey @HarryMWinters,

Thanks for this project, it's saved me a bit of time!

Adding a pull request to enable the audience to be configured. I'm working with Okta configurable Authorization Servers and would prefer my audience claim to be the URL to my API. Having it as the clientId isn't the end of the world, but having the option to configure it will make things more flexible.

Thanks again