### PR TITLE
Add IDtoken type(s) and get_auth to __init__.py

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.9]
       fail-fast: false
 
     steps:
@@ -24,6 +24,9 @@ jobs:
       
       - name: Install Task
         uses: arduino/setup-task@v1
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
 
       - name: Run CI
         run: task ci

--- a/fastapi_oidc/__init__.py
+++ b/fastapi_oidc/__init__.py
@@ -1,0 +1,3 @@
+from fastapi_oidc.auth import get_auth  # noqa
+from fastapi_oidc.types import IDToken  # noqa
+from fastapi_oidc.types import OktaIDToken  # noqa

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,7 @@
+import fastapi_oidc
+
+
+def test_can_import_things_from_project_root():
+    assert fastapi_oidc.IDToken
+    assert fastapi_oidc.OktaIDToken
+    assert fastapi_oidc.get_auth


### PR DESCRIPTION
- Adds IDoken types to root init for project level imports.
- Adds get_auth to root init.
- Adds tests to protect import functionality.

closes #20 