### PR TITLE
change the `get_auth` function signature to use a bare `*` instead of `*_,` so that the function requires keyword-only args without introducing an untyped varargs parameter.

### DIFF
--- a/fastapi_oidc/auth.py
+++ b/fastapi_oidc/auth.py
@@ -34,7 +34,7 @@ from fastapi_oidc.types import IDToken
 
 
 def get_auth(
-    *_,
+    *,
     client_id: str,
     audience: Optional[str] = None,
     base_authorization_server_uri: str,


### PR DESCRIPTION
- Currently `get_auth` is defined as `def get_auth(*_, client_id: str, ...)` which accepts arbitrary positional args via `*_`.
- The untyped varargs show up to type-checkers (Pylance/Pyright) as `Unknown` and leads to diagnostics like `reportUnknownVariableType` in consumer projects (even when `python.analysis.useLibraryCodeForTypes` is enabled).
- Replacing `*_,` with `*` keeps the function semantics (forces subsequent parameters to be keyword-only) without introducing an untyped parameter that causes analyzer warnings.

Closes #52 