### PR TITLE
 Allow multiple issuers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Support for multiple accepted issuers: `get_auth(issuer=...)` now accepts an
+  iterable of issuer strings in addition to a single string
+- `types-python-jose` stubs so mypy can type-check the `jose` imports
 - Comprehensive modernization of development tooling and dependencies
 - Coverage reporting in CI/CD pipeline with Codecov integration
 - Dependabot configuration for automated dependency updates

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ See the [examples directory](examples/) for provider-specific configurations (co
 |-----------|------|-------------|
 | `client_id` | `str` | OAuth client ID from your provider |
 | `base_authorization_server_uri` | `str` | Base URL of your auth server (e.g., `https://dev-123456.okta.com`) |
-| `issuer` | `str` | Token issuer identifier (usually matches base URI domain) |
+| `issuer` | `str \| Iterable[str]` | Token issuer identifier(s) (usually matches base URI domain). Pass an iterable to accept tokens from any of several issuers |
 | `signature_cache_ttl` | `int` | Cache duration for signing keys in seconds (recommended: 3600) |
 
 ### Optional Parameters
@@ -142,6 +142,16 @@ authenticate_user = get_auth(
     audience="https://yourapi.url.com/api",
     base_authorization_server_uri="https://auth.example.com",
     issuer="auth.example.com",
+    signature_cache_ttl=3600,
+)
+```
+
+**With Multiple Issuers:**
+```python3
+authenticate_user = get_auth(
+    client_id="your-client-id",
+    base_authorization_server_uri="https://auth.example.com",
+    issuer=["auth.example.com", "auth.internal.example.com"],
     signature_cache_ttl=3600,
 )
 ```

--- a/fastapi_oidc/auth.py
+++ b/fastapi_oidc/auth.py
@@ -51,8 +51,10 @@ def get_auth(
         client_id: This string is provided when you register with your resource server.
         base_authorization_server_uri: Everything before /.wellknow in your auth server
             URL. I.E. https://dev-123456.okta.com
-        issuer: Same as base_authorization. This is used to generating OpenAPI3.0 docs
-            which is broken (in OpenAPI/FastAPI) right now.
+        issuer: The expected value(s) of the token's ``iss`` claim. Pass a single
+            string to accept one issuer, or an iterable of strings to accept tokens
+            from any of several issuers (useful when the same auth server is reachable
+            under more than one issuer identifier).
         signature_cache_ttl: How many seconds your app should cache the authorization
             server's public signatures.
         audience: The audience string configured by your auth server. If not set

--- a/fastapi_oidc/auth.py
+++ b/fastapi_oidc/auth.py
@@ -15,6 +15,7 @@ Usage
         return f"Hello {name}"
 """
 
+from collections.abc import Iterable
 from typing import Callable
 from typing import Optional
 from typing import Type
@@ -37,7 +38,7 @@ def get_auth(
     client_id: str,
     audience: Optional[str] = None,
     base_authorization_server_uri: str,
-    issuer: str,
+    issuer: str | Iterable[str],
     signature_cache_ttl: int,
     token_type: Type[IDToken] = IDToken,
 ) -> Callable[[str], IDToken]:

--- a/fastapi_oidc/types.py
+++ b/fastapi_oidc/types.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterable
+
 from pydantic import BaseModel
 from pydantic import ConfigDict
 
@@ -5,7 +7,7 @@ from pydantic import ConfigDict
 class OIDCConfig(BaseModel):
     client_id: str
     base_authorization_server_uri: str
-    issuer: str
+    issuer: str | Iterable[str]
     signature_cache_ttl: str
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2048,6 +2048,33 @@ files = [
 ]
 
 [[package]]
+name = "types-pyasn1"
+version = "0.6.0.20260408"
+description = "Typing stubs for pyasn1"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "types_pyasn1-0.6.0.20260408-py3-none-any.whl", hash = "sha256:ee7fbd98bce61193c5d4f8f7812fa53cddc5b8cc5ceb9fcda6eea539947c6d6b"},
+    {file = "types_pyasn1-0.6.0.20260408.tar.gz", hash = "sha256:32dc90927adbe504fd2eee83ae30cf5ef934e5db0d1d94886071fed47eb50c8c"},
+]
+
+[[package]]
+name = "types-python-jose"
+version = "3.5.0.20260408"
+description = "Typing stubs for python-jose"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "types_python_jose-3.5.0.20260408-py3-none-any.whl", hash = "sha256:968d8a8eac1ff9da249d6335a2bb9f82288d59ba23afe91fcc2662eb9f485e2a"},
+    {file = "types_python_jose-3.5.0.20260408.tar.gz", hash = "sha256:3f8dccdc327bfffea7a81084ea1cea722fa499f13c1d04f7978b491dd36e0cf1"},
+]
+
+[package.dependencies]
+types-pyasn1 = "*"
+
+[[package]]
 name = "types-requests"
 version = "2.32.0.20240712"
 description = "Typing stubs for requests"
@@ -2360,4 +2387,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "1248a31ffeee9152986fcad59a288780906745bd46c9bd064647de3d973fa883"
+content-hash = "eeed420bb29f20908cb8c3b9b2b0b1838f910eb23d5d45d816adb2a9b3769a5f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ mypy = "^1.11.0"
 types-cachetools = "^0.1.9"
 types-requests = "^2.25.0"
 pre-commit = "^3.0.0"
+types-python-jose = "^3.3"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -228,6 +228,76 @@ def test_wrong_issuer(
         authenticate_user(auth_header=f"Bearer {wrong_issuer_token}")
 
 
+def test_multiple_issuers_accepts_any_configured(
+    monkeypatch, mock_discovery, config_w_aud, test_email, private_key
+):
+    """Tokens from any issuer in the configured iterable are accepted."""
+    monkeypatch.setattr("fastapi_oidc.auth.discovery.configure", mock_discovery)
+
+    second_issuer = "second-issuer.com"
+    now = int(time.time())
+    token = jwt.encode(
+        {
+            "aud": config_w_aud["audience"],
+            "iss": second_issuer,  # Not the primary issuer, but still allowed
+            "email": test_email,
+            "sub": "test-sub",
+            "exp": now + 300,
+            "iat": now,
+            "auth_time": now,
+            "ver": "1",
+            "jti": str(uuid.uuid4()),
+            "amr": [],
+            "idp": "",
+            "nonce": "",
+            "at_hash": "",
+        },
+        private_key,
+        algorithm="RS256",
+    )
+
+    config = {**config_w_aud, "issuer": [config_w_aud["issuer"], second_issuer]}
+    authenticate_user = get_auth(**config)
+
+    result = authenticate_user(auth_header=f"Bearer {token}")
+    assert result.iss == second_issuer
+    assert result.email == test_email
+
+
+def test_multiple_issuers_rejects_unlisted(
+    monkeypatch, mock_discovery, config_w_aud, test_email, private_key
+):
+    """Tokens whose issuer is not in the configured iterable are rejected."""
+    monkeypatch.setattr("fastapi_oidc.auth.discovery.configure", mock_discovery)
+
+    now = int(time.time())
+    token = jwt.encode(
+        {
+            "aud": config_w_aud["audience"],
+            "iss": "unlisted-issuer.com",  # Not in the allowed list
+            "email": test_email,
+            "sub": "test-sub",
+            "exp": now + 300,
+            "iat": now,
+            "auth_time": now,
+            "ver": "1",
+            "jti": str(uuid.uuid4()),
+            "amr": [],
+            "idp": "",
+            "nonce": "",
+            "at_hash": "",
+        },
+        private_key,
+        algorithm="RS256",
+    )
+
+    config = {**config_w_aud, "issuer": ["first-issuer.com", "second-issuer.com"]}
+    authenticate_user = get_auth(**config)
+
+    with pytest.raises(Exception):  # Should raise HTTPException
+        authenticate_user(auth_header=f"Bearer {token}")
+
+
 def test_wrong_audience(
     monkeypatch, mock_discovery, config_w_aud, test_email, private_key
 ):


### PR DESCRIPTION
## Description

Updates the type hints to allow multiple issuers which was already possible because of the underlying jwt.decode call.

## Motivation and Context

It allows for the resource servers to receive tokens from the same authentication server that
might have different issuers due to how its contacted.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Test addition or modification
- [ ] Dependency update
- [ ] CI/CD changes

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->
<!-- Include details of your test environment and test cases -->

- [x] Existing unit tests pass locally
- [x] Added new unit tests for this change
- [x] Tested manually with Keycloak
- [x] All pre-commit hooks pass

**Test Configuration:**
- Python version: 3.13
- FastAPI version: 0.128.0
- Authentication provider (if applicable): Keycloak

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have updated the CHANGELOG.md (if applicable)