### PR TITLE
ci: add Python 3.13 and 3.14 to the test matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,12 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Python 3.13+ excluded temporarily due to dependency compatibility issues.
-        # PyO3 (used by cryptography and pydantic-core) has limited support for
-        # newer Python versions when building from source on Linux. Prebuilt wheels
-        # may work on some platforms but CI needs reliable cross-platform builds.
-        # Will add back when the ecosystem fully supports these versions.
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Examples directory with working applications for multiple OIDC providers
 
 ### Changed
+- Added Python 3.13 and 3.14 to the CI test matrix (the dependency ecosystem now
+  ships prebuilt wheels for these versions, so the temporary exclusion is removed)
 - Bumped dependencies (consolidating outstanding Dependabot updates):
   - fastapi: 0.111.1 → 0.137.0 (pulls in starlette 1.x)
   - sphinx: 7.4.7 → 8.1.3


### PR DESCRIPTION
## Description

Adds **Python 3.13 and 3.14** to the CI test matrix. These were temporarily excluded because the compiled dependencies (cryptography/PyO3, pydantic-core) didn't yet ship wheels for newer Python on Linux. That's no longer the case — after the dependency consolidation in #96, all compiled deps now have prebuilt 3.13/3.14 wheels.

## Changes
- `.github/workflows/tests.yaml`: matrix `["3.10", "3.11", "3.12"]` → `["3.10", "3.11", "3.12", "3.13", "3.14"]`, and removed the stale exclusion comment.
- `CHANGELOG.md`: noted the matrix addition.

No package-file change is needed: `python = "^3.10"` already permits 3.13/3.14, and the locked dependency versions support them.

## Verification
Ran the full suite locally on **standard CPython 3.13.11 and 3.14.2** — 30 passed, coverage gate met on both.

Compiled-dependency wheel coverage confirmed for 3.13/3.14:
| Package | Version |
|---|---|
| cryptography | 46.0.7 (abi3) |
| pydantic-core | 2.41.5 |
| cffi | 2.0.0 |
| uvloop / httptools / watchfiles | 0.22.1 / 0.8.0 / 1.2.0 |

> Note: 3.15 is still only an alpha, so it's intentionally left out of the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
