### PR TITLE
chore(release): 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-06-14
+
 ### Added
 - Support for multiple accepted issuers: `get_auth(issuer=...)` now accepts an
   iterable of issuer strings in addition to a single string
@@ -48,7 +50,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - pyjwt: 1.7.1 → 2.0.0
   - pre-commit: 2.13.0 → 3.0.0
 - Updated GitHub Actions to latest versions (checkout@v4, setup-python@v5, setup-task@v2)
-- Added Python 3.13 to CI test matrix
 - Standardized type hints to use modern Python 3.10+ syntax (`dict`, `list` instead of `Dict`, `List`)
 - Modernized test utilities to use `pathlib.Path` instead of `os.path`
 - Enhanced README.md with comprehensive documentation sections
@@ -70,5 +71,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - get_auth function signature uses bare `*` for keyword-only arguments
 
-[Unreleased]: https://github.com/HarryMWinters/fastapi-oidc/compare/v0.0.11...HEAD
+[Unreleased]: https://github.com/HarryMWinters/fastapi-oidc/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/HarryMWinters/fastapi-oidc/compare/v0.0.11...v0.1.0
 [0.0.11]: https://github.com/HarryMWinters/fastapi-oidc/releases/tag/v0.0.11

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = "2020, Harry M. Winters"
 author = "Harry M. Winters"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.11"
+release = "0.1.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/fastapi_oidc/__init__.py
+++ b/fastapi_oidc/__init__.py
@@ -26,4 +26,4 @@ from fastapi_oidc.types import IDToken
 from fastapi_oidc.types import OktaIDToken
 
 __all__ = ["get_auth", "IDToken", "OktaIDToken"]
-__version__ = "0.0.11"
+__version__ = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-oidc"
-version = "0.0.11"
+version = "0.1.0"
 description = "A simple library for parsing and verifying externally issued OIDC ID tokens in fastapi."
 authors = ["HarryMWinters <harrymcwinters@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Release 0.1.0

Version-bump + changelog roll-up for the **0.1.0** release.

### Why 0.1.0 (minor, not patch)
This release contains a **breaking change** — `TokenSpecificationError` now inherits from `Exception` instead of `BaseException` — so per SemVer for a 0.x project the minor is bumped.

### Included since 0.0.11
- **Added:** multiple-issuer support (`get_auth(issuer=...)` accepts an iterable), `types-python-jose` stubs, tooling modernization, examples, integration/edge-case tests.
- **Changed:** Python 3.13 + 3.14 added to the CI matrix; consolidated dependency bumps (fastapi 0.137, starlette 1.x, sphinx 8.1.3, etc.); `httpx` + `uvicorn[standard]` as explicit dev deps.
- **Fixed (BREAKING):** `TokenSpecificationError` base class.

### Files
- `pyproject.toml`, `fastapi_oidc/__init__.py`, `docs/conf.py` → `0.1.0`
- `CHANGELOG.md` → `[Unreleased]` rolled into `[0.1.0] - 2026-06-14`, compare links updated

Verified: all three version strings consistent, `poetry build` produces `fastapi_oidc-0.1.0` sdist + wheel.

After merge, this commit gets tagged `v0.1.0` and published to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
